### PR TITLE
feat: implement NMS scalar baseline with unit tests

### DIFF
--- a/inc/gradient.hpp
+++ b/inc/gradient.hpp
@@ -127,36 +127,35 @@ template <typename PixelT = uint8_t, typename GradientT = int32_t>
         return (image.buffer && Gx && Gy) ? Status::E_NOK : Status::E_INVAL_PTR;
     }
 
-    GradientT x;
-    GradientT y;
-    uint16_t abs_x;
-    uint16_t abs_y;
     uint8_t angle;
     for(uint32_t i = 0; i < image.pixel_count; ++i)
     {
-        x = std::abs(Gx[i]);
-        y = std::abs(Gy[i]);
-        abs_x = static_cast<uint16_t>(x);
-        abs_y = static_cast<uint16_t>(y);
+        const GradientT cur_x = Gx[i];
+        const GradientT cur_y = Gy[i];
+        const uint16_t abs_x = static_cast<uint16_t>(std::abs(cur_x));
+        const uint16_t abs_y = static_cast<uint16_t>(std::abs(cur_y));
 
-        if((abs_y * 5) > (abs_x * 12))
+        if ((abs_y * 5) > (abs_x * 12)) // > 2.4 (Vertical gradient)
         {
             angle = 90;
         }
-        else if((abs_y * 5) > (abs_x * 2))
+        else if ((abs_y * 2) > abs_x) // > 0.5 (Diagonal range)
         {
-            angle = 0;
-        }
-        else
-        {
-            if(((x > 0) && (y > 0)) || ((x < 0) && (y < 0)))
-            {
-                angle = 45;
-            }
-            else
+            // In image coordinates, y increases downwards.
+            // cur_x > 0, cur_y > 0 is Down-Right (135 deg)
+            // cur_x > 0, cur_y < 0 is Up-Right (45 deg)
+            if (((cur_x > 0) && (cur_y > 0)) || ((cur_x < 0) && (cur_y < 0)))
             {
                 angle = 135;
             }
+            else
+            {
+                angle = 45;
+            }
+        }
+        else // < 0.5 (Horizontal range)
+        {
+            angle = 0;
         }
         image.buffer[i] = angle;
     }

--- a/inc/nonmaximum_suppression.hpp
+++ b/inc/nonmaximum_suppression.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file    nonmaximum_suppression.hpp
+ * @brief   Non-maximum suppression implementation for thinning edges.
+ */
+
+#pragma once
+
+#include "std_types.hpp"
+#include <cstdint>
+#include <memory>
+#include <cstring>
+
+namespace processing
+{
+
+/** @brief Performs non-maximum suppression to thin edges.
+ * @param magnitude The input gradient magnitude image.
+ * @param direction The input gradient direction image (angles 0, 45, 90, 135).
+ * @param out       The output thinned image.
+ * @return Status indicating success or failure.
+ */
+template <typename PixelT = uint8_t>
+[[nodiscard]] Status nms(const image::io::metadata_t<PixelT>& magnitude,
+                         const image::io::metadata_t<PixelT>& direction,
+                         image::io::metadata_t<PixelT>& out)
+{
+    if (!magnitude.buffer || !direction.buffer || !out.buffer)
+    {
+        return Status::E_INVAL_PTR;
+    }
+
+    if (magnitude.width != direction.width || magnitude.height != direction.height ||
+        magnitude.width != out.width || magnitude.height != out.height)
+    {
+        return Status::E_NOK;
+    }
+
+    const uint32_t width = magnitude.width;
+    const uint32_t height = magnitude.height;
+
+    // Initialize output buffer with 0
+    std::memset(out.buffer.get(), 0, out.aligned_buffer_size * sizeof(PixelT));
+
+    for (uint32_t y = 1; y < height - 1; ++y)
+    {
+        for (uint32_t x = 1; x < width - 1; ++x)
+        {
+            const uint32_t idx = y * width + x;
+            const PixelT mag = magnitude.buffer[idx];
+            const PixelT angle = direction.buffer[idx];
+
+            PixelT q = 255;
+            PixelT r = 255;
+
+            // Angle 0: Horizontal - compare left and right neighbors
+            if (angle == 0)
+            {
+                q = magnitude.buffer[idx + 1];
+                r = magnitude.buffer[idx - 1];
+            }
+            // Angle 45: Diagonal / - compare top-right and bottom-left neighbors
+            else if (angle == 45)
+            {
+                q = magnitude.buffer[(y - 1) * width + (x + 1)];
+                r = magnitude.buffer[(y + 1) * width + (x - 1)];
+            }
+            // Angle 90: Vertical - compare top and bottom neighbors
+            else if (angle == 90)
+            {
+                q = magnitude.buffer[(y - 1) * width + x];
+                r = magnitude.buffer[(y + 1) * width + x];
+            }
+            // Angle 135: Diagonal \ - compare top-left and bottom-right neighbors
+            else if (angle == 135)
+            {
+                q = magnitude.buffer[(y - 1) * width + (x - 1)];
+                r = magnitude.buffer[(y + 1) * width + (x + 1)];
+            }
+
+            out.buffer[idx] = (mag >= q && mag >= r) ? mag : static_cast<PixelT>(0);
+        }
+    }
+
+    return Status::E_OK;
+}
+
+} // namespace processing

--- a/tests/io_tests.cpp
+++ b/tests/io_tests.cpp
@@ -1,20 +1,28 @@
 #include "io.hpp"
+#include "utils.hpp"
 #include <iostream>
 #include <string_view>
-#include <vector>
 #include <cstdint>
 
-image::io::metadata_t raw_image
+int main()
 {
-    .image_width = 512,
-    .image_height = 512,
-};
+    const uint32_t w = 512;
+    const uint32_t h = 512;
+    const size_t pixel_count  = static_cast<size_t>(w) * h;
+    const size_t aligned_size = utils::memory::align_64(pixel_count);
 
-int main() {
+    image::io::metadata_t<uint8_t> raw_image;
+    raw_image.width              = w;
+    raw_image.height             = h;
+    raw_image.pixel_count        = pixel_count;
+    raw_image.aligned_buffer_size = aligned_size;
+    raw_image.buffer.reset(static_cast<uint8_t*>(
+        utils::memory::aligned_alloc(64, aligned_size)));
+
     Status load_status = image::io::load_raw<uint8_t>("rect.raw", raw_image);
     std::cout << "Load Status: " << static_cast<int>(load_status) << std::endl;
 
-    Status save_status = image::io::save_raw<uint8_t>("rect_copyy.raw", raw_image);
+    Status save_status = image::io::save_raw<uint8_t>("rect_copy.raw", raw_image);
     std::cout << "Save Status: " << static_cast<int>(save_status) << std::endl;
 
     return 0;

--- a/tests/nms_tests.cpp
+++ b/tests/nms_tests.cpp
@@ -1,0 +1,183 @@
+#include <iostream>
+#include <cstring>
+#include "std_types.hpp"
+#include "nonmaximum_suppression.hpp"
+#include "utils.hpp"
+
+#define ASSERT_TEST(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            std::cerr << "[FAIL] " << msg << std::endl; \
+            return 1; \
+        } else { \
+            std::cout << "[PASS] " << msg << std::endl; \
+        } \
+    } while(0)
+
+/**
+ * @brief Helper to allocate and initialise a metadata_t image of size w x h,
+ *        with all pixels set to 0.
+ */
+static image::io::metadata_t<uint8_t> make_image(uint32_t w, uint32_t h)
+{
+    const size_t pixel_count   = static_cast<size_t>(w) * h;
+    const size_t aligned_size  = utils::memory::align_64(pixel_count);
+    image::io::metadata_t<uint8_t> img;
+    img.width              = w;
+    img.height             = h;
+    img.pixel_count        = pixel_count;
+    img.aligned_buffer_size = aligned_size;
+    img.buffer.reset(static_cast<uint8_t*>(utils::memory::aligned_alloc(64, aligned_size)));
+    std::memset(img.buffer.get(), 0, aligned_size);
+    return img;
+}
+
+int main()
+{
+    std::cout << "--- NMS Unit Tests ---" << std::endl;
+
+    // -------------------------------------------------------
+    // Test 1: Null pointer guard
+    // -------------------------------------------------------
+    {
+        image::io::metadata_t<uint8_t> mag, dir, out;  // all buffers null
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_INVAL_PTR, "Null pointer check");
+    }
+
+    // -------------------------------------------------------
+    // Test 2: Horizontal direction (angle = 0)
+    //   Grid (5x5), single horizontal ridge at row y=2:
+    //      col:  0    1    2    3    4
+    //   y=2:  [  0, 100, 200, 100,   0 ]   dir=0 for all
+    //   Expected after NMS: only (y=2, x=2) survives.
+    // -------------------------------------------------------
+    {
+        const uint32_t W = 5, H = 5;
+        auto mag = make_image(W, H);
+        auto dir = make_image(W, H);
+        auto out = make_image(W, H);
+
+        mag.buffer[2 * W + 1] = 100;
+        mag.buffer[2 * W + 2] = 200;  // peak
+        mag.buffer[2 * W + 3] = 100;
+
+        // direction = 0 for the whole ridge
+        dir.buffer[2 * W + 1] = 0;
+        dir.buffer[2 * W + 2] = 0;
+        dir.buffer[2 * W + 3] = 0;
+
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_OK, "Horizontal NMS status");
+        ASSERT_TEST(out.buffer[2 * W + 2] == 200, "Horizontal NMS: peak preserved");
+        ASSERT_TEST(out.buffer[2 * W + 1] == 0,   "Horizontal NMS: left suppressed");
+        ASSERT_TEST(out.buffer[2 * W + 3] == 0,   "Horizontal NMS: right suppressed");
+    }
+
+    // -------------------------------------------------------
+    // Test 3: Vertical direction (angle = 90)
+    //   Grid (5x5), single vertical ridge at col x=2:
+    //      row:  0    1    2    3    4
+    //   x=2:  [  0, 100, 200, 100,   0 ]   dir=90
+    //   Expected after NMS: only (y=2, x=2) survives.
+    // -------------------------------------------------------
+    {
+        const uint32_t W = 5, H = 5;
+        auto mag = make_image(W, H);
+        auto dir = make_image(W, H);
+        auto out = make_image(W, H);
+
+        mag.buffer[1 * W + 2] = 100;
+        mag.buffer[2 * W + 2] = 200;  // peak
+        mag.buffer[3 * W + 2] = 100;
+
+        dir.buffer[1 * W + 2] = 90;
+        dir.buffer[2 * W + 2] = 90;
+        dir.buffer[3 * W + 2] = 90;
+
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_OK, "Vertical NMS status");
+        ASSERT_TEST(out.buffer[2 * W + 2] == 200, "Vertical NMS: peak preserved");
+        ASSERT_TEST(out.buffer[1 * W + 2] == 0,   "Vertical NMS: top suppressed");
+        ASSERT_TEST(out.buffer[3 * W + 2] == 0,   "Vertical NMS: bottom suppressed");
+    }
+
+    // -------------------------------------------------------
+    // Test 4: Diagonal / direction (angle = 45)
+    //   Grid (5x5), diagonal ridge (top-right to bottom-left):
+    //     (1,3)=100  (2,2)=200  (3,1)=100  -- dir=45 for all
+    //   Neighbors of peak (2,2) are (1,3)=100 and (3,1)=100.
+    //   Expected: (2,2) preserved, (1,3) and (3,1) suppressed.
+    // -------------------------------------------------------
+    {
+        const uint32_t W = 5, H = 5;
+        auto mag = make_image(W, H);
+        auto dir = make_image(W, H);
+        auto out = make_image(W, H);
+
+        // Diagonal /: q = (y-1, x+1), r = (y+1, x-1)
+        // For peak at (y=2,x=2): q=(1,3)=100, r=(3,1)=100
+        mag.buffer[1 * W + 3] = 100;   // q for peak
+        mag.buffer[2 * W + 2] = 200;   // peak
+        mag.buffer[3 * W + 1] = 100;   // r for peak
+
+        dir.buffer[1 * W + 3] = 45;
+        dir.buffer[2 * W + 2] = 45;
+        dir.buffer[3 * W + 1] = 45;
+
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_OK, "Diagonal-/ NMS status");
+        ASSERT_TEST(out.buffer[2 * W + 2] == 200, "Diagonal-/ NMS: peak preserved");
+        ASSERT_TEST(out.buffer[1 * W + 3] == 0,   "Diagonal-/ NMS: top-right suppressed");
+        ASSERT_TEST(out.buffer[3 * W + 1] == 0,   "Diagonal-/ NMS: bottom-left suppressed");
+    }
+
+    // -------------------------------------------------------
+    // Test 5: Diagonal \ direction (angle = 135)
+    //   Grid (5x5), diagonal ridge (top-left to bottom-right):
+    //     (1,1)=100  (2,2)=200  (3,3)=100  -- dir=135 for all
+    //   Neighbors of peak (2,2) are (1,1)=100 and (3,3)=100.
+    //   Expected: (2,2) preserved, (1,1) and (3,3) suppressed.
+    // -------------------------------------------------------
+    {
+        const uint32_t W = 5, H = 5;
+        auto mag = make_image(W, H);
+        auto dir = make_image(W, H);
+        auto out = make_image(W, H);
+
+        // Diagonal \: q = (y-1, x-1), r = (y+1, x+1)
+        // For peak at (y=2,x=2): q=(1,1)=100, r=(3,3)=100
+        mag.buffer[1 * W + 1] = 100;   // q for peak
+        mag.buffer[2 * W + 2] = 200;   // peak
+        mag.buffer[3 * W + 3] = 100;   // r for peak
+
+        dir.buffer[1 * W + 1] = 135;
+        dir.buffer[2 * W + 2] = 135;
+        dir.buffer[3 * W + 3] = 135;
+
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_OK, "Diagonal-\\ NMS status");
+        ASSERT_TEST(out.buffer[2 * W + 2] == 200, "Diagonal-\\ NMS: peak preserved");
+        ASSERT_TEST(out.buffer[1 * W + 1] == 0,   "Diagonal-\\ NMS: top-left suppressed");
+        ASSERT_TEST(out.buffer[3 * W + 3] == 0,   "Diagonal-\\ NMS: bottom-right suppressed");
+    }
+
+    // -------------------------------------------------------
+    // Test 6: Pixel at border is untouched (stays 0)
+    // -------------------------------------------------------
+    {
+        const uint32_t W = 5, H = 5;
+        auto mag = make_image(W, H);
+        auto dir = make_image(W, H);
+        auto out = make_image(W, H);
+
+        mag.buffer[0 * W + 0] = 255;   // corner pixel, should be left as 0 in output
+
+        Status s = processing::nms(mag, dir, out);
+        ASSERT_TEST(s == Status::E_OK,            "Border pixel NMS status");
+        ASSERT_TEST(out.buffer[0 * W + 0] == 0,   "Border pixel stays 0");
+    }
+
+    std::cout << "--- All NMS tests passed ---" << std::endl;
+    return 0;
+}

--- a/tools/unit_tests_raw_generator.py
+++ b/tools/unit_tests_raw_generator.py
@@ -2,6 +2,7 @@ import os
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
+import unittest
 
 ## @class UnitTestsRawGenerator
 #  @brief A utility class for generating basic geometric unit test raw images as NumPy arrays.
@@ -54,33 +55,115 @@ class UnitTestsRawGenerator:
                     img[y, x] = 255
         return img
 
+    ## @brief Generates a horizontal white line on a black background.
+    #  @param y The vertical position of the line.
+    #  @param x_range A tuple (start, end) for the horizontal range.
+    #  @return A NumPy array representing the horizontal line.
+    def horizontal_line(self, y=100, x_range=(50, 200)):
+        img = self.background.copy()
+        img[y, x_range[0]:x_range[1]] = 255
+        return img
+
+    ## @brief Generates a vertical white line on a black background.
+    #  @param x The horizontal position of the line.
+    #  @param y_range A tuple (start, end) for the vertical range.
+    #  @return A NumPy array representing the vertical line.
+    def vertical_line(self, x=100, y_range=(50, 200)):
+        img = self.background.copy()
+        img[y_range[0]:y_range[1], x] = 255
+        return img
+
+    ## @brief Generates an inverse diagonal edge (135 degrees) within a specified bounding box.
+    #  @param top_left The upper-left corner of the region of interest.
+    #  @param bottom_right The lower-right corner of the region of interest.
+    #  @return A NumPy array with a 135-degree diagonal edge.
+    def diagonal_edge_inv(self, top_left=(50, 50), bottom_right=(200, 200)):
+        img = self.background.copy()
+        y_start, y_end = top_left[1], bottom_right[1]
+        x_start, x_end = top_left[0], bottom_right[0]
+        width = x_end - x_start
+        for y in range(y_start, y_end):
+            for x in range(x_start, x_end):
+                if (x - x_start) + (y - y_start) < width:
+                    img[y, x] = 255
+        return img
+
+
+## @class TestUnitTestsRawGenerator
+#  @brief Unit tests for the UnitTestsRawGenerator class.
+class TestUnitTestsRawGenerator(unittest.TestCase):
+    def setUp(self):
+        self.size = 100
+        self.gen = UnitTestsRawGenerator(size=self.size)
+
+    def test_rectangle(self):
+        img = self.gen.rectangle(top_left=(10, 10), bottom_right=(20, 20))
+        self.assertEqual(img.shape, (self.size, self.size))
+        self.assertEqual(img[15, 15], 255)
+        self.assertEqual(img[5, 5], 0)
+
+    def test_circle(self):
+        img = self.gen.circle(top_left=(10, 10), bottom_right=(30, 30))
+        # Center is at (20, 20), radius is 10
+        self.assertEqual(img[20, 20], 255)
+        self.assertEqual(img[0, 0], 0)
+
+    def test_horizontal_line(self):
+        img = self.gen.horizontal_line(y=50, x_range=(10, 90))
+        self.assertEqual(img[50, 50], 255)
+        self.assertEqual(img[51, 50], 0)
+
+    def test_vertical_line(self):
+        img = self.gen.vertical_line(x=50, y_range=(10, 90))
+        self.assertEqual(img[50, 50], 255)
+        self.assertEqual(img[50, 51], 0)
+
+    def test_diagonal_edge(self):
+        img = self.gen.diagonal_edge(top_left=(10, 10), bottom_right=(90, 90))
+        # 45 degree: x-x0 > y-y0 -> 255
+        self.assertEqual(img[20, 30], 255)  # 30-10 > 20-10 (20 > 10)
+        self.assertEqual(img[30, 20], 0)    # 20-10 > 30-10 (10 > 20)
+
+    def test_diagonal_edge_inv(self):
+        img = self.gen.diagonal_edge_inv(top_left=(10, 10), bottom_right=(90, 90))
+        # 135 degree: (x-x0) + (y-y0) < width -> 255
+        # width = 80
+        self.assertEqual(img[20, 20], 255)  # (10) + (10) < 80
+        self.assertEqual(img[80, 80], 0)    # (70) + (70) < 80
+
 
 if __name__ == "__main__":
-    ## @details Entry point for the script. 
-    #  Parses command line arguments for image dimensions and saves
-    #  generated assets to a '../assets' directory in raw binary format.
-    try:
-        image_width = int(sys.argv[1]) if len(sys.argv) > 1 else 512
-        image_height = int(sys.argv[2]) if len(sys.argv) > 2 else image_width
-    except:
-        print("Invalid dimensions provided. Usage: python script.py [width] [height]")
-        sys.exit(1)
+    if len(sys.argv) > 1 and sys.argv[1] == "--test":
+        sys.argv.pop(1)
+        unittest.main()
+    else:
+        # Existing main logic
+        try:
+            image_width = int(sys.argv[1]) if len(sys.argv) > 1 else 512
+            image_height = int(sys.argv[2]) if len(sys.argv) > 2 else image_width
+        except:
+            print("Invalid dimensions provided. Usage: python script.py [width] [height]")
+            sys.exit(1)
 
-    gen = UnitTestsRawGenerator(size=max(image_height,image_width))
+        gen = UnitTestsRawGenerator(size=max(image_height, image_width))
 
-    # Determine paths
-    assets_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../assets'))
-    if not os.path.exists(assets_path):
-        os.makedirs(assets_path)
+        # Determine paths
+        assets_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../assets'))
+        if not os.path.exists(assets_path):
+            os.makedirs(assets_path)
 
-    # Generate image dictionary
-    images = {
-        "rect": gen.rectangle()[:image_height, :image_width],
-        "circ": gen.circle()[:image_height, :image_width], 
-        "diag": gen.diagonal_edge()[:image_height, :image_width]
-    }
+        # Generate image dictionary
+        images = {
+            "rect": gen.rectangle()[:image_height, :image_width],
+            "circ": gen.circle()[:image_height, :image_width],
+            "diag": gen.diagonal_edge()[:image_height, :image_width],
+            "diag_inv": gen.diagonal_edge_inv()[:image_height, :image_width],
+            "horiz": gen.horizontal_line()[:image_height, :image_width],
+            "vert": gen.vertical_line()[:image_height, :image_width]
+        }
 
-    # Save images as raw binary files
-    for filename, data in images.items():
-        filepath = os.path.join(assets_path, f"{filename}.raw")
-        data.tofile(filepath)
+        # Save images as raw binary files
+        for filename, data in images.items():
+            filepath = os.path.join(assets_path, f"{filename}.raw")
+            data.tofile(filepath)
+            print(f"Generated {filepath}")


### PR DESCRIPTION
- Add inc/nonmaximum_suppression.hpp with scalar NMS implementation supporting all 4 quantized gradient directions (0, 45, 90, 135 deg)
- Add tests/nms_tests.cpp with 19 isolated unit tests covering all directions, border behaviour, and null pointer guard
- Fix bug in inc/gradient.hpp direction(): variables x/y were assigned std::abs() values before sign comparison, making diagonal quadrant detection always fall into the same branch; keep signed cur_x/cur_y and compute abs_x/abs_y separately
- Fix diagonal angle threshold in gradient.hpp: change abs_y*5 > abs_x*2 (slope > 0.4) to abs_y*2 > abs_x (slope > 0.5) for correct 4-way quantization; swap 45/135 labels to match image-coordinate convention
- Fix compile error in tests/io_tests.cpp: replace stale field names image_width/image_height with current width/height from metadata_t, and add proper aligned buffer allocation

All 5 test suites pass under qemu-riscv64 vlen=512.