### PR TITLE
Phase4/benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ SRCS        := $(wildcard src/*.cpp)
 LIB_SRCS    := $(filter-out src/main.cpp, $(SRCS))
 
 RV_FLAGS = -std=c++23 -march=rv64gcv -O3 -static -Iinc
+RV_FLAGS_BASE = -std=c++23 -march=rv64gcv -static -Iinc
 HOST_FLAGS = -std=c++23 -O3 -I$(GTEST)/include -L$(GTEST)/lib -lgtest -lgtest_main -lpthread
 
 # Targets
-.PHONY: all clean run test run-test list-tests
+.PHONY: all clean run test run-test list-tests \
+        bench_O0 bench_O2 bench_O3 bench_Os bench_Ofast bench_all \
+        autovec_report size_report
 
 all: canny_rv test
 
@@ -47,3 +50,51 @@ run-tests: build/target/debug/$(NAME).elf
 # Utility to see what you can run
 list-tests:
 	@ls tests/*.cpp | xargs -n 1 basename | sed 's/\.cpp//'
+
+
+# ── PHASE 4: BENCHMARKING ──────────────────────────────────────
+
+bench_O0: $(SRCS)
+	@mkdir -p ./build/bench
+	$(RV_CXX) $(RV_FLAGS_BASE) -O0 $(SRCS) -o build/bench/canny_O0.elf
+	@echo "=== -O0 ==="
+	qemu-riscv64 -cpu max,vlen=512 build/bench/canny_O0.elf
+
+bench_O2: $(SRCS)
+	@mkdir -p ./build/bench
+	$(RV_CXX) $(RV_FLAGS_BASE) -O2 $(SRCS) -o build/bench/canny_O2.elf
+	@echo "=== -O2 ==="
+	qemu-riscv64 -cpu max,vlen=512 build/bench/canny_O2.elf
+
+bench_O3: $(SRCS)
+	@mkdir -p ./build/bench
+	$(RV_CXX) $(RV_FLAGS_BASE) -O3 $(SRCS) -o build/bench/canny_O3.elf
+	@echo "=== -O3 ==="
+	qemu-riscv64 -cpu max,vlen=512 build/bench/canny_O3.elf
+
+bench_Os: $(SRCS)
+	@mkdir -p ./build/bench
+	$(RV_CXX) $(RV_FLAGS_BASE) -Os $(SRCS) -o build/bench/canny_Os.elf
+	@echo "=== -Os ==="
+	qemu-riscv64 -cpu max,vlen=512 build/bench/canny_Os.elf
+
+bench_Ofast: $(SRCS)
+	@mkdir -p ./build/bench
+	$(RV_CXX) $(RV_FLAGS_BASE) -Ofast $(SRCS) -o build/bench/canny_Ofast.elf
+	@echo "=== -Ofast ==="
+	qemu-riscv64 -cpu max,vlen=512 build/bench/canny_Ofast.elf
+
+# Run all benchmarks sequentially
+bench_all: bench_O0 bench_O2 bench_O3 bench_Os bench_Ofast
+
+# Auto-vectorization report (saved to results/)
+autovec_report: $(SRCS)
+	@mkdir -p ./build/bench ./results
+	$(RV_CXX) $(RV_FLAGS_BASE) -O3 -fopt-info-vec-all $(SRCS) \
+	    -o build/bench/canny_autovec.elf 2> results/autovec_report.txt
+	@echo "Saved to results/autovec_report.txt"
+
+# Binary size comparison
+size_report:
+	@echo "=== Binary sizes ==="
+	@ls -lh build/bench/*.elf 2>/dev/null || echo "Run make bench_all first"

--- a/results/autovec_report.txt
+++ b/results/autovec_report.txt
@@ -1,0 +1,419 @@
+src/main.cpp: In function ‘int main()’:
+src/main.cpp:69:36: warning: ignoring return value of ‘Status processing::spatial_5x5(image::io::metadata_t<PixelT>&) [with PixelT = unsigned char; AccumulatorT = int]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+   69 |             processing::spatial_5x5(img_copy);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+In file included from src/main.cpp:2:
+inc/gaussian.hpp:38:22: note: declared here
+   38 | [[nodiscard]] Status spatial_5x5(image::io::metadata_t<PixelT>& image)
+      |                      ^~~~~~~~~~~
+src/main.cpp:86:38: warning: ignoring return value of ‘Status processing::separable_5x5(image::io::metadata_t<PixelT>&) [with PixelT = unsigned char; AccumulatorT = int]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+   86 |             processing::separable_5x5(img_copy);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+inc/gaussian.hpp:100:22: note: declared here
+  100 | [[nodiscard]] Status separable_5x5(image::io::metadata_t<PixelT>& image)
+      |                      ^~~~~~~~~~~~~
+src/main.cpp:92:32: warning: ignoring return value of ‘Status processing::spatial_3x3(const image::io::metadata_t<PixelT>&, OutputT*, OutputT*) [with PixelT = unsigned char; OutputT = short int]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+   92 |         processing::spatial_3x3(image, gx, gy);
+      |         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+In file included from src/main.cpp:3:
+inc/sobel.hpp:22:22: note: declared here
+   22 | [[nodiscard]] Status spatial_3x3(const image::io::metadata_t<PixelT>& image,
+      |                      ^~~~~~~~~~~
+src/main.cpp:107:27: warning: ignoring return value of ‘Status processing::l1(const image::io::metadata_t<PixelT>&, const GradientT*, const GradientT*) [with PixelT = unsigned char; GradientT = short int; MagT = short unsigned int]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+  107 |             processing::l1(mag, gx, gy);
+      |             ~~~~~~~~~~~~~~^~~~~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+In file included from src/main.cpp:4:
+inc/gradient.hpp:23:22: note: declared here
+   23 | [[nodiscard]] Status l1(const image::io::metadata_t<PixelT>& image,
+      |                      ^~
+src/main.cpp:123:27: warning: ignoring return value of ‘Status processing::l2(const image::io::metadata_t<PixelT>&, const GradientT*, const GradientT*) [with PixelT = unsigned char; GradientT = short int; MagT = float]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+  123 |             processing::l2(mag, gx, gy);
+      |             ~~~~~~~~~~~~~~^~~~~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+inc/gradient.hpp:70:22: note: declared here
+   70 | [[nodiscard]] Status l2(const image::io::metadata_t<PixelT>& image,
+      |                      ^~
+src/main.cpp:146:34: warning: ignoring return value of ‘Status processing::direction(const image::io::metadata_t<PixelT>&, const GradientT*, const GradientT*) [with PixelT = unsigned char; GradientT = int]’, declared with attribute ‘nodiscard’ [-Wunused-result]
+  146 |             processing::direction(dir, gx32, gy32);
+      |             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
+src/main.cpp:51:42: note: in definition of macro ‘BENCH’
+   51 |     for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+      |                                          ^~~~
+inc/gradient.hpp:120:22: note: declared here
+  120 | [[nodiscard]] Status direction(const image::io::metadata_t<PixelT>& image,
+      |                      ^~~~~~~~~
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (_6, _5);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:172:26: missed: statement clobbers memory: operator delete (_11, _16);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:355:5: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:172:26: missed: statement clobbers memory: operator delete (_5, _9);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:284:7: note: ***** Analysis failed with vector mode DI
+inc/io.hpp:31:22: missed: splitting region at control altering definition _114 = operator new (_108);
+inc/io.hpp:44:39: missed: statement clobbers memory: raw_ptr_20 = aligned_alloc (64, _30);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (__old_p_29);
+/usr/riscv64-linux-gnu/include/c++/13/bits/char_traits.h:435:49: missed: statement clobbers memory: __builtin_memcpy (&MEM[(struct basic_string *)&D.151490].D.41906._M_local_buf, "./assets/", 9);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:331:70: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::_List::_List (&D.151490._M_cmpts);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:332:23: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::_M_split_cmpts (&D.151490);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (&MEM[(struct _Head_base &)&D.151490 + 32]._M_head_impl, _67);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 19
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:804:19: missed: statement clobbers memory: std::__cxx11::basic_string<char>::_M_dispose (&D.151490._M_pathname);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: missed: not vectorized: statement can throw an exception: _114 = operator new (_108);
+inc/io.hpp:52:26: note: ***** Analysis failed with vector mode DI
+inc/io.hpp:52:26: missed: splitting region at dominance boundary bb26
+inc/io.hpp:52:26: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:52:26: missed: splitting region at dominance boundary bb30
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:250:31: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:250:31: missed: splitting region at dominance boundary bb22
+/usr/riscv64-linux-gnu/include/c++/13/bits/char_traits.h:435:49: missed: statement clobbers memory: __builtin_memcpy (_95, SR.282_60, SR.281_59);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:223:28: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:223:28: missed: splitting region at dominance boundary bb19
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: missed: not vectorized: statement can throw an exception: std::__throw_bad_alloc ();
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: missed: splitting region at dominance boundary bb15
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: missed: not vectorized: statement can throw an exception: std::__throw_length_error ("basic_string::_M_create");
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: missed: splitting region at dominance boundary bb31
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:624:15: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:624:15: missed: splitting region at control altering definition _217 = operator new (_136);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:331:70: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::_List::_List (&D.151491._M_cmpts);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:332:23: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::_M_split_cmpts (&D.151491);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (&MEM[(struct _Head_base &)&D.151491 + 32]._M_head_impl, _62);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 17
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:804:19: missed: statement clobbers memory: std::__cxx11::basic_string<char>::_M_dispose (&D.151491._M_pathname);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 16
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: missed: not vectorized: statement can throw an exception: _217 = operator new (_136);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: missed: splitting region at dominance boundary bb48
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:151:48: missed: splitting region at dominance boundary bb52
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:250:31: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:250:31: missed: splitting region at dominance boundary bb53
+/usr/riscv64-linux-gnu/include/c++/13/bits/char_traits.h:435:49: missed: statement clobbers memory: __builtin_memcpy (_93, _117, _118);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:223:28: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:223:28: missed: splitting region at control altering definition _179 = std::basic_filebuf<char>::open (&file._M_filebuf, _43, 12);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:317:5: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::_List::_List (&file_path._M_cmpts, &D.151490._M_cmpts);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:804:19: missed: statement clobbers memory: std::__cxx11::basic_string<char>::_M_dispose (&file_path._M_pathname);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 20
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:594:19: missed: not vectorized: statement can throw an exception: std::filesystem::__cxx11::path::operator/= (&file_path, &D.151491);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:596:5: missed: statement clobbers memory: std::filesystem::__cxx11::path::~path (&file_path);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 15
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (&MEM[(struct _Head_base &)&D.151491 + 32]._M_head_impl, _162);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:172:26: missed: statement clobbers memory: operator delete (_165, _170);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (&MEM[(struct _Head_base &)&D.151490 + 32]._M_head_impl, _159);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:172:26: missed: statement clobbers memory: operator delete (_171, _176);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:59: missed: statement clobbers memory: std::ios_base::ios_base (&MEM[(struct basic_ios *)&file + 256B].D.60145);
+/usr/riscv64-linux-gnu/include/c++/13/istream:698:19: missed: not vectorized: statement can throw an exception: std::basic_ios<char>::init (_152, 0B);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:537:27: missed: not vectorized: statement can throw an exception: std::basic_filebuf<char>::basic_filebuf (&file._M_filebuf);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:539:12: missed: not vectorized: statement can throw an exception: std::basic_ios<char>::init (&MEM <struct ifstream> [(void *)&file + 256B], &file._M_filebuf.D.112127);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:667:22: missed: not vectorized: statement can throw an exception: _179 = std::basic_filebuf<char>::open (&file._M_filebuf, _43, 12);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: ***** Analysis succeeded with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: SLPing BB part
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: Costing subgraph: 
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: node 0x2c136d30 (max_nunits=1, refcnt=1) vector(1) long unsigned int
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: op template: MEM[(struct basic_ios *)&file + 256B]._M_streambuf = 0B;
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	stmt 0 MEM[(struct basic_ios *)&file + 256B]._M_streambuf = 0B;
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	stmt 1 MEM[(struct basic_ios *)&file + 256B]._M_ctype = 0B;
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	stmt 2 MEM[(struct basic_ios *)&file + 256B]._M_num_put = 0B;
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	stmt 3 MEM[(struct basic_ios *)&file + 256B]._M_num_get = 0B;
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	children 0x2c136ca8
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: node (constant) 0x2c136ca8 (max_nunits=1, refcnt=1) vector(1) long unsigned int
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: 	{ 0B, 0B, 0B, 0B }
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: Cost model analysis: 
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: Cost model analysis for part in loop 0:
+  Vector cost: 5
+  Scalar cost: 4
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: missed: not vectorized: vectorization is not profitable.
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: missed: splitting region at dominance boundary bb72
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:462:2: missed: splitting region at dominance boundary bb79
+/usr/riscv64-linux-gnu/include/c++/13/fstream:672:15: missed: not vectorized: statement can throw an exception: std::basic_ios<char>::clear (_195, 0);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:158:20: missed: not vectorized: statement can throw an exception: std::basic_ios<char>::clear (_195, _189);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:158:20: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:158:20: missed: splitting region at dominance boundary bb82
+/usr/riscv64-linux-gnu/include/c++/13/fstream:541:7: missed: statement clobbers memory: std::basic_filebuf<char>::~basic_filebuf (&file._M_filebuf);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 23
+/usr/riscv64-linux-gnu/include/c++/13/fstream:541:7: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/fstream:541:7: missed: splitting region at dominance boundary bb85
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 22
+/usr/riscv64-linux-gnu/include/c++/13/istream:106:19: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/istream:106:19: missed: splitting region at dominance boundary bb119
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: missed: statement clobbers memory: std::ios_base::~ios_base (&MEM[(struct basic_ios *)&file + 256B].D.60145);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 21
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: missed: splitting region at dominance boundary bb77
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: missed: splitting region at control altering definition _32 = std::basic_istream<char>::read (&file.D.112319, _46, total_bytes.2_5);
+inc/io.hpp:63:19: missed: not vectorized: statement can throw an exception: _32 = std::basic_istream<char>::read (&file.D.112319, _46, total_bytes.2_5);
+inc/io.hpp:63:19: note: ***** Analysis failed with vector mode DI
+inc/io.hpp:63:19: missed: splitting region at dominance boundary bb101
+inc/io.hpp:63:5: note: ***** Analysis failed with vector mode DI
+inc/io.hpp:63:5: missed: splitting region at dominance boundary bb104
+inc/io.hpp:69:1: missed: statement clobbers memory: std::basic_ifstream<char>::~basic_ifstream (&file);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 11
+inc/io.hpp:69:1: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:69:1: missed: splitting region at dominance boundary bb121
+inc/io.hpp:69:1: missed: statement clobbers memory: std::filesystem::__cxx11::path::~path (&file_path);
+inc/io.hpp:69:1: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:69:1: missed: splitting region at dominance boundary bb88
+inc/io.hpp:69:1: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:69:1: missed: splitting region at dominance boundary bb44
+/usr/riscv64-linux-gnu/include/c++/13/fstream:256:17: missed: not vectorized: statement can throw an exception: std::basic_filebuf<char>::close (&file._M_filebuf);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:257:2: missed: statement clobbers memory: _203 = __builtin_eh_pointer (25);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:257:2: missed: statement clobbers memory: __cxa_begin_catch (_203);
+/usr/riscv64-linux-gnu/include/c++/13/fstream:257:2: missed: statement clobbers memory: __cxa_end_catch ();
+/usr/riscv64-linux-gnu/include/c++/13/fstream:259:7: missed: statement clobbers memory: std::__basic_file<char>::~__basic_file (&MEM[(struct basic_filebuf *)&file + 16B]._M_file);
+/usr/riscv64-linux-gnu/include/c++/13/streambuf:205:9: missed: statement clobbers memory: std::locale::~locale (&MEM[(struct basic_streambuf *)&file + 16B]._M_buf_locale);
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_ios.h:282:22: missed: statement clobbers memory: std::ios_base::~ios_base (&MEM[(struct basic_ios *)&file + 256B].D.60145);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:404:17: missed: statement clobbers memory: std::filesystem::__cxx11::path::_List::_Impl_deleter::operator() (&MEM[(struct _Head_base &)&file_path + 32]._M_head_impl, _190);
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:172:26: missed: statement clobbers memory: operator delete (_204, _209);
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:355:5: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/fs_path.h:355:5: missed: splitting region at dominance boundary bb42
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: missed: not vectorized: statement can throw an exception: std::__throw_bad_alloc ();
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/new_allocator.h:140:28: missed: splitting region at dominance boundary bb97
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: missed: not vectorized: statement can throw an exception: std::__throw_length_error ("basic_string::_M_create");
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.tcc:144:27: missed: splitting region at dominance boundary bb16
+inc/io.hpp:55:27: missed: statement clobbers memory: std::filesystem::__cxx11::path::~path (&D.151491);
+inc/io.hpp:31:22: missed: not vectorized: statement can throw an exception: resx 5
+inc/io.hpp:55:27: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:55:27: missed: splitting region at dominance boundary bb100
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:625:28: missed: not vectorized: statement can throw an exception: std::__throw_logic_error ("basic_string: construction from null is not valid");
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:625:28: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/basic_string.h:625:28: missed: splitting region at dominance boundary bb106
+inc/io.hpp:55:56: missed: statement clobbers memory: std::filesystem::__cxx11::path::~path (&D.151490);
+inc/io.hpp:55:56: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:55:56: missed: splitting region at dominance boundary bb105
+inc/io.hpp:55:56: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:55:56: missed: splitting region at dominance boundary bb95
+inc/io.hpp:55:56: note: ***** Analysis failed with vector mode VOID
+inc/io.hpp:31:22: note: ***** Analysis failed with vector mode VOID
+src/main.cpp:145:9: missed: couldn't vectorize loop
+src/main.cpp:145:9: missed: not vectorized: control flow in loop.
+inc/gradient.hpp:131:27: missed: couldn't vectorize loop
+inc/gradient.hpp:131:27: missed: not vectorized: control flow in loop.
+src/main.cpp:143:30: missed: couldn't vectorize loop
+src/main.cpp:143:56: missed: not vectorized: relevant stmt not supported: _24 = (int) _21;
+src/main.cpp:122:9: missed: couldn't vectorize loop
+src/main.cpp:122:9: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/gradient.hpp:105:27: missed: couldn't vectorize loop
+inc/gradient.hpp:107:65: missed: not vectorized: no vectype for stmt: _692 = *_691;
+ scalar_type: float
+inc/gradient.hpp:90:27: missed: couldn't vectorize loop
+inc/gradient.hpp:96:27: missed: not vectorized: data ref analysis failed: *_682 = _680;
+inc/gradient.hpp:90:27: note: ***** Analysis failed with vector mode DI
+src/main.cpp:106:9: missed: couldn't vectorize loop
+src/main.cpp:106:9: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/gradient.hpp:55:27: missed: couldn't vectorize loop
+inc/gradient.hpp:57:25: missed: not vectorized: data ref analysis failed: *_652 = _650;
+inc/gradient.hpp:43:27: missed: couldn't vectorize loop
+inc/gradient.hpp:46:27: missed: not vectorized: data ref analysis failed: *_633 = value_632;
+src/main.cpp:91:5: missed: couldn't vectorize loop
+src/main.cpp:91:5: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/sobel.hpp:31:27: missed: couldn't vectorize loop
+inc/sobel.hpp:31:27: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/sobel.hpp:40:31: missed: couldn't vectorize loop
+inc/sobel.hpp:45:43: missed: not vectorized: data ref analysis failed: *_592 = _593;
+inc/sobel.hpp:40:31: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algo.h:757:7: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algo.h:757:7: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/gaussian.hpp:142:27: missed: couldn't vectorize loop
+inc/gaussian.hpp:147:76: missed: not vectorized: data ref analysis failed: _120 = *_315;
+inc/gaussian.hpp:143:31: missed: couldn't vectorize loop
+inc/gaussian.hpp:145:38: missed: not vectorized: relevant stmt not supported: _489 = x_350 + 2;
+inc/gaussian.hpp:123:28: missed: couldn't vectorize loop
+inc/gaussian.hpp:128:24: missed: not vectorized: data ref analysis failed: _894 = *_893;
+inc/gaussian.hpp:124:44: missed: couldn't vectorize loop
+inc/gaussian.hpp:131:42: missed: not vectorized: data ref analysis failed: *_477 = sum_960;
+inc/gaussian.hpp:117:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:398:10: missed: not vectorized: data ref analysis failed: *_440 = _443;
+inc/gaussian.hpp:117:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:398:10: missed: not vectorized: data ref analysis failed: *_1979 = _1976;
+inc/gaussian.hpp:117:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (_2009, _2023, _2008);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algo.h:757:7: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algo.h:757:7: missed: not vectorized: loop nest containing two or more consecutive inner loops cannot be vectorized
+inc/gaussian.hpp:69:27: missed: couldn't vectorize loop
+inc/gaussian.hpp:78:28: missed: not vectorized: data ref analysis failed: _1079 = *_1078;
+inc/gaussian.hpp:70:31: missed: couldn't vectorize loop
+inc/gaussian.hpp:78:28: missed: not vectorized: unsupported use in stmt.
+inc/gaussian.hpp:54:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:398:10: missed: not vectorized: data ref analysis failed: *_343 = _345;
+inc/gaussian.hpp:54:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:398:10: missed: not vectorized: data ref analysis failed: *_2034 = _2031;
+inc/gaussian.hpp:54:27: missed: couldn't vectorize loop
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (_2053, _2059, _2052);
+src/main.cpp:20:5: note: vectorized 0 loops in function.
+src/main.cpp:20:5: missed: splitting region at control altering definition _57 = image::io::load_raw<unsigned char> (D.146606, &image);
+src/main.cpp:31:36: missed: not vectorized: statement can throw an exception: _57 = image::io::load_raw<unsigned char> (D.146606, &image);
+src/main.cpp:28:18: note: ***** Analysis succeeded with vector mode DI
+src/main.cpp:28:18: note: SLPing BB part
+src/main.cpp:28:18: note: Costing subgraph: 
+src/main.cpp:28:18: note: node 0x2c2bf278 (max_nunits=2, refcnt=1) vector(2) unsigned int
+src/main.cpp:28:18: note: op template: image.width = 512;
+src/main.cpp:28:18: note: 	stmt 0 image.width = 512;
+src/main.cpp:28:18: note: 	stmt 1 image.height = 512;
+src/main.cpp:28:18: note: 	children 0x2c2bf300
+src/main.cpp:28:18: note: node (constant) 0x2c2bf300 (max_nunits=1, refcnt=1) vector(2) unsigned int
+src/main.cpp:28:18: note: 	{ 512, 512 }
+src/main.cpp:28:18: note: Cost model analysis: 
+src/main.cpp:28:18: note: Cost model analysis for part in loop 0:
+  Vector cost: 2
+  Scalar cost: 2
+src/main.cpp:28:18: note: Basic block will be vectorized using SLP
+src/main.cpp:28:18: note: Vectorizing SLP tree:
+src/main.cpp:28:18: note: node 0x2c2bf278 (max_nunits=2, refcnt=1) vector(2) unsigned int
+src/main.cpp:28:18: note: op template: image.width = 512;
+src/main.cpp:28:18: note: 	stmt 0 image.width = 512;
+src/main.cpp:28:18: note: 	stmt 1 image.height = 512;
+src/main.cpp:28:18: note: 	children 0x2c2bf300
+src/main.cpp:28:18: note: node (constant) 0x2c2bf300 (max_nunits=1, refcnt=1) vector(2) unsigned int
+src/main.cpp:28:18: note: 	{ 512, 512 }
+src/main.cpp:28:18: note: ------>vectorizing SLP node starting from: image.width = 512;
+src/main.cpp:28:18: note: vect_is_simple_use: operand 512, type of def: constant
+src/main.cpp:28:18: note: transform store. ncopies = 1
+src/main.cpp:28:18: note: create vector_type-pointer variable to type: vector(2) unsigned int  vectorizing a pointer ref: image.width
+src/main.cpp:28:18: note: created &image.width
+src/main.cpp:28:18: note: add new stmt: MEM <vector(2) unsigned int> [(unsigned int *)&image + 8B] = { 512, 512 };
+src/main.cpp:28:18: note: vectorizing stmts using SLP.
+src/main.cpp:28:18: optimized: basic block part vectorized using 8 byte vectors
+src/main.cpp:28:18: missed: splitting region at control altering definition _328 = operator new [] (_327);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _150 = aligned_alloc (64, size_149);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _145 = aligned_alloc (64, size_149);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _155 = aligned_alloc (64, size_154);
+src/main.cpp:67:9: missed: statement clobbers memory: clock_gettime (1, &t0);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (img_copy_103, pretmp_1586, n_60);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: not vectorized: statement can throw an exception: _328 = operator new [] (_327);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: splitting region at dominance boundary bb28
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: splitting region at dominance boundary bb447
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: statement clobbers memory: __builtin_memset (_328, 0, _1964);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:931:11: missed: statement clobbers memory: __builtin_memset (_328, 0, _1965);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _252 = aligned_alloc (64, size_154);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (_2053, _2059, _2052);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _360 = aligned_alloc (64, size_154);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_103);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: missed: statement clobbers memory: operator delete [] (_328);
+inc/gaussian.hpp:78:78: note: ***** Analysis failed with vector mode DI
+inc/gaussian.hpp:78:78: missed: splitting region at dominance boundary bb46
+inc/gaussian.hpp:78:78: note: ***** Analysis failed with vector mode VOID
+inc/gaussian.hpp:78:78: missed: splitting region at loop 1 exit at bb47
+src/main.cpp:67:9: note: ***** Analysis failed with vector mode VOID
+src/main.cpp:67:9: missed: splitting region at dominance boundary bb189
+src/main.cpp:67:9: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Gaussian spatial", _7);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: splitting region at dominance boundary bb49
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_86);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 6
+inc/std_types.hpp:37:8: note: ***** Analysis failed with vector mode VOID
+inc/std_types.hpp:37:8: missed: splitting region at control altering definition _428 = operator new [] (_327);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_566);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _165 = aligned_alloc (64, size_154);
+src/main.cpp:84:9: missed: statement clobbers memory: clock_gettime (1, &t0);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (img_copy_84, pretmp_1586, n_60);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: not vectorized: statement can throw an exception: _428 = operator new [] (_327);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: splitting region at dominance boundary bb63
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: splitting region at control altering definition _530 = operator new [] (iftmp.42_529);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: statement clobbers memory: __builtin_memset (_428, 0, _1960);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:931:11: missed: statement clobbers memory: __builtin_memset (_428, 0, _1961);
+/usr/riscv64-linux-gnu/include/c++/13/bits/stl_algobase.h:437:23: missed: statement clobbers memory: __builtin_memcpy (_2009, _2023, _2008);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: not vectorized: statement can throw an exception: _530 = operator new [] (iftmp.42_529);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: splitting region at dominance boundary bb74
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: missed: statement clobbers memory: operator delete [] (_1066);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 27
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: note: ***** Analysis failed with vector mode VOID
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: missed: splitting region at dominance boundary bb437
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:1085:30: missed: statement clobbers memory: __builtin_memset (_530, 0, _1958);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _762 = aligned_alloc (64, size_154);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _487 = aligned_alloc (64, size_154);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_84);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: missed: statement clobbers memory: operator delete [] (_530);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:140:4: missed: statement clobbers memory: operator delete [] (_428);
+inc/gaussian.hpp:147:67: note: ***** Analysis failed with vector mode DI
+inc/gaussian.hpp:147:67: missed: splitting region at dominance boundary bb450
+inc/gaussian.hpp:147:67: note: ***** Analysis failed with vector mode VOID
+inc/gaussian.hpp:147:67: missed: splitting region at dominance boundary bb90
+inc/gaussian.hpp:147:67: note: ***** Analysis failed with vector mode VOID
+inc/gaussian.hpp:147:67: missed: splitting region at loop 2 exit at bb93
+src/main.cpp:84:9: note: ***** Analysis failed with vector mode VOID
+src/main.cpp:84:9: missed: splitting region at dominance boundary bb194
+src/main.cpp:84:9: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Gaussian separable", _11);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: splitting region at dominance boundary bb95
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_37);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 10
+inc/std_types.hpp:37:8: note: ***** Analysis failed with vector mode VOID
+inc/std_types.hpp:37:8: missed: splitting region at dominance boundary bb240
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (img_copy_1065);
+src/main.cpp:91:5: missed: statement clobbers memory: clock_gettime (1, &t0);
+src/main.cpp:91:5: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Sobel", _13);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _184 = aligned_alloc (64, size_154);
+src/main.cpp:106:9: missed: statement clobbers memory: clock_gettime (1, &t0);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _623 = aligned_alloc (64, size_622);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_623);
+src/main.cpp:106:9: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Magnitude L1", _15);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_184);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 14
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_184);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _192 = aligned_alloc (64, size_154);
+src/main.cpp:122:9: missed: statement clobbers memory: clock_gettime (1, &t0);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _668 = aligned_alloc (64, size_667);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_668);
+src/main.cpp:122:9: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Magnitude L2", _17);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_192);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 18
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_192);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _206 = aligned_alloc (64, size_154);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _205 = aligned_alloc (64, size_204);
+inc/utils.hpp:37:30: missed: statement clobbers memory: _200 = aligned_alloc (64, size_204);
+src/main.cpp:145:9: missed: statement clobbers memory: clock_gettime (1, &t0);
+src/main.cpp:145:9: missed: statement clobbers memory: clock_gettime (1, &t1);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "%-20s %.3f ms/iter\n", "Direction", _30);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_206);
+src/main.cpp:20:5: missed: not vectorized: statement can throw an exception: resx 22
+src/main.cpp:149:18: missed: statement clobbers memory: free (_205);
+src/main.cpp:150:18: missed: statement clobbers memory: free (_200);
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_206);
+src/main.cpp:153:14: missed: statement clobbers memory: free (_150);
+src/main.cpp:154:14: missed: statement clobbers memory: free (_145);
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "\nDone. Image: %ux%u, %d iterations each.\n", 512, 512, 100);
+inc/gradient.hpp:45:14: note: ***** Analysis failed with vector mode DI
+inc/gradient.hpp:45:14: missed: splitting region at dominance boundary bb249
+inc/gradient.hpp:45:14: note: ***** Analysis failed with vector mode VOID
+inc/gradient.hpp:45:14: missed: splitting region at dominance boundary bb11
+inc/gradient.hpp:45:14: note: ***** Analysis failed with vector mode VOID
+inc/gradient.hpp:45:14: missed: splitting region at dominance boundary bb4
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "ERROR: alloc failed\n");
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:673:12: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:673:12: missed: splitting region at dominance boundary bb185
+/usr/riscv64-linux-gnu/include/bits/stdio2.h:86:23: missed: not vectorized: statement can throw an exception: __printf_chk (2, "ERROR: could not load assets/tiger.raw (status=%d)\n", _1);
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:673:12: note: ***** Analysis failed with vector mode DI
+/usr/riscv64-linux-gnu/include/c++/13/bits/unique_ptr.h:673:12: missed: splitting region at dominance boundary bb210
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (prephitmp_2064);
+src/main.cpp:20:5: note: ***** Analysis failed with vector mode VOID
+src/main.cpp:20:5: missed: splitting region at dominance boundary bb211
+src/main.cpp:20:5: note: ***** Analysis failed with vector mode VOID
+inc/utils.hpp:21:18: missed: statement clobbers memory: free (_217);
+inc/std_types.hpp:37:8: note: ***** Analysis failed with vector mode DI

--- a/results/optimization_table.md
+++ b/results/optimization_table.md
@@ -1,0 +1,32 @@
+# Phase 4: Compiler Optimization Results
+
+## Execution Time (ms/iter, 100 iterations, 512x512, VLEN=512)
+
+| Stage              | -O0      | -O2     | -O3     | -Os     | -Ofast  |
+|--------------------|----------|---------|---------|---------|---------|
+| Gaussian spatial   | 1342.077 | 17.135  | 7.372   | 19.518  | 7.478   |
+| Gaussian separable | 702.679  | 7.062   | 3.977   | 8.795   | 4.036   |
+| Sobel              | 5.755    | 2.475   | 2.442   | 1.969   | 2.546   |
+| Magnitude L1       | 161.299  | 7.072   | 6.733   | 7.033   | 6.788   |
+| Magnitude L2       | 197.638  | 11.853  | 12.203  | 34.805  | 15.351  |
+| Direction          | 59.017   | 3.067   | 3.084   | 3.097   | 3.133   |
+
+## Binary Sizes
+
+| Flag    | Size  |
+|---------|-------|
+| -O0     | 3.6M  |
+| -O2     | 2.3M  |
+| -O3     | 2.3M  |
+| -Os     | 3.0M  |
+| -Ofast  | 2.3M  |
+
+## Key Observations
+
+- Gaussian spatial is the heaviest stage: 1342ms at -O0, drops 182x to 7.4ms at -O3
+- Gaussian separable is ~2x faster than spatial at every level — separable filter pays off
+- -O3 and -Ofast are nearly identical, meaning floating-point relaxation gives no benefit here
+- -Os (optimize for size) is slower than -O3 for most stages, but binary size is 3.0M vs 2.3M — worse on both counts
+- Magnitude L2 spikes at -Os (34.8ms vs 12.2ms at -O3) because sqrt() is no longer inlined
+- Sobel and Direction are cheap at all levels — not worth vectorizing manually (Amdahl's law)
+- Hotspots for Phase 6 RVV optimization: Gaussian spatial (7.4ms) and Magnitude L1 (6.7ms)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,158 @@
 #include "io.hpp"
+#include "gaussian.hpp"
+#include "sobel.hpp"
+#include "gradient.hpp"
+#include "std_types.hpp"
+#include "utils.hpp"
 
-int main(int argc, char** argv)
+#include <cstdio>
+#include <cstdint>
+#include <memory>
+#include <time.h>
+
+// ── Timing helper ─────────────────────────────────────────────
+static double elapsed_ms(struct timespec s, struct timespec e)
 {
+    return (e.tv_sec  - s.tv_sec)  * 1000.0
+         + (e.tv_nsec - s.tv_nsec) / 1e6;
+}
 
+int main()
+{
+    constexpr uint32_t WIDTH  = 512;
+    constexpr uint32_t HEIGHT = 512;
+    constexpr int      ITERS  = 100;
+
+    // ── 1. Load image ──────────────────────────────────────────
+    image::io::metadata_t<uint8_t> image;
+    image.width  = WIDTH;
+    image.height = HEIGHT;
+
+    Status st = image::io::load_raw("tiger.raw", image);
+    if (st != Status::E_OK)
+    {
+        printf("ERROR: could not load assets/tiger.raw (status=%d)\n",
+               static_cast<int>(st));
+        return 1;
+    }
+
+    // ── 2. Allocate Sobel output buffers ───────────────────────
+    const size_t n = image.pixel_count;
+
+    auto gx = static_cast<int16_t*>(utils::memory::aligned_alloc(64, n * sizeof(int16_t)));
+    auto gy = static_cast<int16_t*>(utils::memory::aligned_alloc(64, n * sizeof(int16_t)));
+    if (!gx || !gy) { printf("ERROR: alloc failed\n"); return 1; }
+
+    // ── 3. Benchmark helpers ───────────────────────────────────
+    struct timespec t0, t1;
+
+#define BENCH(label, code)                                      \
+    clock_gettime(CLOCK_MONOTONIC, &t0);                        \
+    for (int _i = 0; _i < ITERS; ++_i) { code; }               \
+    clock_gettime(CLOCK_MONOTONIC, &t1);                        \
+    printf("%-20s %.3f ms/iter\n", label,                       \
+           elapsed_ms(t0, t1) / ITERS);
+
+    // ── 4. Gaussian spatial ────────────────────────────────────
+    {
+        image::io::metadata_t<uint8_t> img_copy;
+        img_copy.width              = image.width;
+        img_copy.height             = image.height;
+        img_copy.pixel_count        = image.pixel_count;
+        img_copy.aligned_buffer_size = image.aligned_buffer_size;
+        auto* raw = static_cast<uint8_t*>(
+            utils::memory::aligned_alloc(64, image.aligned_buffer_size));
+        img_copy.buffer.reset(raw);
+
+        BENCH("Gaussian spatial",
+            std::copy_n(image.buffer.get(), n, img_copy.buffer.get());
+            processing::spatial_5x5(img_copy);
+        )
+    }
+
+    // ── 5. Gaussian separable ──────────────────────────────────
+    {
+        image::io::metadata_t<uint8_t> img_copy;
+        img_copy.width              = image.width;
+        img_copy.height             = image.height;
+        img_copy.pixel_count        = image.pixel_count;
+        img_copy.aligned_buffer_size = image.aligned_buffer_size;
+        auto* raw = static_cast<uint8_t*>(
+            utils::memory::aligned_alloc(64, image.aligned_buffer_size));
+        img_copy.buffer.reset(raw);
+
+        BENCH("Gaussian separable",
+            std::copy_n(image.buffer.get(), n, img_copy.buffer.get());
+            processing::separable_5x5(img_copy);
+        )
+    }
+
+    // ── 6. Sobel ───────────────────────────────────────────────
+    BENCH("Sobel",
+        processing::spatial_3x3(image, gx, gy);
+    )
+
+    // ── 7. Magnitude L1 ───────────────────────────────────────
+    {
+        image::io::metadata_t<uint8_t> mag;
+        mag.width              = image.width;
+        mag.height             = image.height;
+        mag.pixel_count        = image.pixel_count;
+        mag.aligned_buffer_size = image.aligned_buffer_size;
+        auto* raw = static_cast<uint8_t*>(
+            utils::memory::aligned_alloc(64, image.aligned_buffer_size));
+        mag.buffer.reset(raw);
+
+        BENCH("Magnitude L1",
+            processing::l1(mag, gx, gy);
+        )
+    }
+
+    // ── 8. Magnitude L2 ───────────────────────────────────────
+    {
+        image::io::metadata_t<uint8_t> mag;
+        mag.width              = image.width;
+        mag.height             = image.height;
+        mag.pixel_count        = image.pixel_count;
+        mag.aligned_buffer_size = image.aligned_buffer_size;
+        auto* raw = static_cast<uint8_t*>(
+            utils::memory::aligned_alloc(64, image.aligned_buffer_size));
+        mag.buffer.reset(raw);
+
+        BENCH("Magnitude L2",
+            processing::l2(mag, gx, gy);
+        )
+    }
+
+    // ── 9. Direction ───────────────────────────────────────────
+    {
+        image::io::metadata_t<uint8_t> dir;
+        dir.width              = image.width;
+        dir.height             = image.height;
+        dir.pixel_count        = image.pixel_count;
+        dir.aligned_buffer_size = image.aligned_buffer_size;
+        auto* raw = static_cast<uint8_t*>(
+            utils::memory::aligned_alloc(64, image.aligned_buffer_size));
+        dir.buffer.reset(raw);
+
+        // direction takes int32_t Gx/Gy — upcast
+        auto gx32 = static_cast<int32_t*>(
+            utils::memory::aligned_alloc(64, n * sizeof(int32_t)));
+        auto gy32 = static_cast<int32_t*>(
+            utils::memory::aligned_alloc(64, n * sizeof(int32_t)));
+        for (size_t i = 0; i < n; ++i) { gx32[i] = gx[i]; gy32[i] = gy[i]; }
+
+        BENCH("Direction",
+            processing::direction(dir, gx32, gy32);
+        )
+
+        std::free(gx32);
+        std::free(gy32);
+    }
+
+    std::free(gx);
+    std::free(gy);
+
+    printf("\nDone. Image: %ux%u, %d iterations each.\n", WIDTH, HEIGHT, ITERS);
     return 0;
 }


### PR DESCRIPTION
## What this PR does
Implements Phase 4 of the Canny Edge Detection project: measuring the 
effect of compiler optimization flags on pipeline performance.

## Changes
- Added `RV_FLAGS_BASE` to Makefile to support multiple optimization levels
- Added benchmark targets: `bench_O0`, `bench_O2`, `bench_O3`, `bench_Os`, 
  `bench_Ofast`, `bench_all`, `autovec_report`, `size_report`
- Added timing harness to `main.cpp` using `clock_gettime` measuring each 
  pipeline stage over 100 iterations
- Added `results/optimization_table.md` with full results
- Added `results/autovec_report.txt` from `-O3 -fopt-info-vec-all` build

## Results Summary
Tested on 512x512 tiger.raw, VLEN=512, 100 iterations each.

| Stage              | -O0      | -O3    | Speedup |
|--------------------|----------|--------|---------|
| Gaussian spatial   | 1342 ms  | 7.4 ms | ~182x   |
| Gaussian separable | 702 ms   | 3.9 ms | ~180x   |
| Magnitude L1       | 161 ms   | 6.7 ms | ~24x    |
| Magnitude L2       | 197 ms   | 12 ms  | ~16x    |
| Direction          | 59 ms    | 3 ms   | ~20x    |

## Key Findings
- Gaussian is the bottleneck — primary target for Phase 6 RVV optimization
- Separable filter is ~2x faster than spatial at every optimization level
- `-O3` and `-Ofast` perform nearly identically
- `-Os` increases binary size unexpectedly while being slower than `-O3`
